### PR TITLE
Fix/galaxy cleanup

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -201,7 +201,7 @@ Both `awscli` and `sshuttle` are included in the `requirements-devel.txt`, so sh
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `VERSION` | The version of the collection and EE to package/use | 0.4.0 |
+| `VERSION` | The version of the collection and EE to package/use | 0.4.1 |
 | `GALAXY_TOKEN` | The API token from Ansible Galaxy for publishing a collection | Read at runtime from `.galaxy-token` |
 | `PUSH_IMAGE` | The container image name that the EE will be pushed to for publishing | registry.jharmison.com/ansible/oc-mirror-e2e |
 | `RUNTIME` | The OCI container runtime to use for operations that need one | `podman` |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.4.0
+VERSION = 0.4.1
 GALAXY_TOKEN := $(shell cat .galaxy-token)
 PUSH_IMAGE = registry.jharmison.com/ansible/oc-mirror-e2e
 RUNTIME = podman

--- a/collection/roles/logged_in/README.md
+++ b/collection/roles/logged_in/README.md
@@ -1,0 +1,4 @@
+logged_in
+=========
+
+This role logs in to or out of an OpenShift cluster, depending on the value of `state`, and registers the token and API endpoints for consumption by follow-on tasks that need authenticated access to OpenShift. Its use is in flux and the interface is likely to change in the near term.

--- a/collection/roles/operators/README.md
+++ b/collection/roles/operators/README.md
@@ -1,0 +1,4 @@
+operators
+=========
+
+This role is designed to perform operations on a logged in OpenShift cluster for testing the installation and use of Operators. The interface is currently not well defined and in rapid flux.


### PR DESCRIPTION
- Adds skeleton readmes for roles that lacked them
- Enables publishing to Ansible Galaxy (hopefully?)