### PR TITLE
Changed to HTTPS module source

### DIFF
--- a/collection/playbooks/vars/scenario_stubs/operators_to_mirror/ansible_operator.yml
+++ b/collection/playbooks/vars/scenario_stubs/operators_to_mirror/ansible_operator.yml
@@ -1,0 +1,10 @@
+# The ImageSetConfiguration operator blurb's schema is too complex to fully
+#   parametrize. It's easier to simply pass it in as a string, so we do.
+operator_blurb: |
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ openshift_version }}
+      headsOnly: false
+      packages:
+        - name: ansible-automation-platform-operator
+          channels:
+            - name: stable-2.1

--- a/collection/roles/provisioner/files/terraform/main.tf
+++ b/collection/roles/provisioner/files/terraform/main.tf
@@ -1,5 +1,5 @@
 module "testbed" {
-  source = "git://github.com/jharmison-redhat/disconnected-openshift-testbed.git?ref=0.2.4"
+  source = "git::https://github.com/jharmison-redhat/disconnected-openshift-testbed.git?ref=0.2.4"
 
   public_key       = var.public_key
   cluster_name     = var.cluster_name


### PR DESCRIPTION
Corrects `fatal: remote error: The unauthenticated git protocol on port 9418 is no longer supported.` error on Terraform Apply.