### PR TITLE
Enable CI image build methodology

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -213,7 +213,7 @@ Both `awscli` and `sshuttle` are included in the `requirements-devel.txt`, so sh
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `VERSION` | The version of the collection and EE to package/use | 0.4.11 |
+| `VERSION` | The version of the collection and EE to package/use | 0.5.0 |
 | `GALAXY_TOKEN` | The API token from Ansible Galaxy for publishing a collection | Read at runtime from `.galaxy-token` |
 | `PUSH_IMAGE` | The container image name that the EE will be pushed to for publishing | registry.jharmison.com/ansible/oc-mirror-e2e |
 | `RUNTIME` | The OCI container runtime to use for operations that need one | `podman` |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.4.11
+VERSION = 0.5.0
 GALAXY_TOKEN := $(shell cat .galaxy-token)
 PUSH_IMAGE = registry.jharmison.com/ansible/oc-mirror-e2e
 RUNTIME = podman

--- a/collection/playbooks/delete.yml
+++ b/collection/playbooks/delete.yml
@@ -15,8 +15,8 @@
       tasks_from: uninstalled.yml
     vars:
       install_directory: '{{ output_dir }}/install'
-      oc_path: '{{ output_dir }}/clients/oc'
-      openshift_install_path: '{{ output_dir }}/clients/openshift-install'
+      oc_path: '{{ oc_bin|default(output_dir+"/clients/oc") }}'
+      openshift_install_path: '{{ openshift_install_bin|default(output_dir+"/clients/openshift-install" }}'
       extra_uninstall_env:
         AWS_ACCESS_KEY_ID: '{{ lookup("ini", "aws_access_key_id", section="default", file=(output_dir + "/aws_credentials")) }}'
         AWS_SECRET_ACCESS_KEY: '{{ lookup("ini", "aws_secret_access_key", section="default", file=(output_dir + "/aws_credentials")) }}'

--- a/collection/playbooks/delete.yml
+++ b/collection/playbooks/delete.yml
@@ -16,7 +16,7 @@
     vars:
       install_directory: '{{ output_dir }}/install'
       oc_path: '{{ oc_bin|default(output_dir+"/clients/oc") }}'
-      openshift_install_path: '{{ openshift_install_bin|default(output_dir+"/clients/openshift-install" }}'
+      openshift_install_path: '{{ openshift_install_bin|default(output_dir+"/clients/openshift-install") }}'
       extra_uninstall_env:
         AWS_ACCESS_KEY_ID: '{{ lookup("ini", "aws_access_key_id", section="default", file=(output_dir + "/aws_credentials")) }}'
         AWS_SECRET_ACCESS_KEY: '{{ lookup("ini", "aws_secret_access_key", section="default", file=(output_dir + "/aws_credentials")) }}'

--- a/collection/playbooks/delete.yml
+++ b/collection/playbooks/delete.yml
@@ -24,9 +24,6 @@
   - name: Destroy the terraform deployment
     include_role:
       name: provisioner
-      tasks_from: terraform
-    vars:
-      tf_task_state: absent
-      public_key: '{{ lookup("file", output_dir + "/" + cluster_name + "_ed25519.pub", errors="ignore")|default("") }}'
+      tasks_from: destroyed.yml
   tags:
   - always

--- a/collection/playbooks/terraform_setup.yml
+++ b/collection/playbooks/terraform_setup.yml
@@ -1,0 +1,12 @@
+---
+- name: Setup the terraform environment for CI
+  hosts: controller
+  vars_files:
+  - '{{ playbook_dir }}/vars/defaults.yml'
+  tasks:
+  - name: Setup the terraform environment
+    include_role:
+      name: provisioner
+      tasks_from: setup.yml
+  tags:
+  - always

--- a/collection/roles/provisioner/tasks/destroyed.yml
+++ b/collection/roles/provisioner/tasks/destroyed.yml
@@ -1,0 +1,16 @@
+---
+- name: Ensure terraform setup is completed
+  include_tasks: setup.yml
+
+- name: Generate an OpenSSH keypair (it can be fake, as long as it exists)
+  community.crypto.openssh_keypair:
+    path: '{{ output_dir }}/{{ cluster_name }}_ed25519'
+    type: ed25519
+    comment: '{{ registry_admin.email }}'
+  register: keypair
+
+- name: Apply the terraform deployment
+  include_tasks: terraform.yml
+  vars:
+      public_key: '{{ keypair.public_key }}'
+      tf_task_state: absent

--- a/collection/roles/provisioner/tasks/main.yml
+++ b/collection/roles/provisioner/tasks/main.yml
@@ -11,16 +11,8 @@
     comment: '{{ registry_admin.email }}'
   register: keypair
 
-- name: Copy the terraform to the output
-  copy:
-    src: '{{ role_path }}/files/terraform'
-    dest: '{{ output_dir }}/'
-    remote_src: yes
-
-- name: Generate the backend config
-  template:
-    src: backend-config.hcl.j2
-    dest: '{{ output_dir }}/terraform/backend-config.hcl'
+- name: Ensure terraform setup is completed
+  include_tasks: setup.yml
 
 - name: Apply the terraform deployment
   include_tasks: terraform.yml

--- a/collection/roles/provisioner/tasks/main.yml
+++ b/collection/roles/provisioner/tasks/main.yml
@@ -19,6 +19,12 @@
   vars:
       public_key: '{{ keypair.public_key }}'
 
+- name: Generate a terraform destroy script
+  template:
+    src: tf-destroy.sh.j2
+    dest: '{{ output_dir }}/terraform/tf-destroy.sh'
+    mode: '0755'
+
 - name: Update the inventory
   include_tasks: inventory.yml
 

--- a/collection/roles/provisioner/tasks/setup.yml
+++ b/collection/roles/provisioner/tasks/setup.yml
@@ -19,7 +19,7 @@
   - name: Initialize Terraform
     shell: |
       cd {{ output_dir }}/terraform
-      terraform init -backend-config=backend-config.hcl
+      {{ terraform_binary_path|default("terraform") }} init -backend-config=backend-config.hcl
     when: not tf_lock.stat.exists
     register: tf_init
   always:

--- a/collection/roles/provisioner/tasks/setup.yml
+++ b/collection/roles/provisioner/tasks/setup.yml
@@ -1,0 +1,32 @@
+---
+- name: Copy the terraform to the output
+  copy:
+    src: '{{ role_path }}/files/terraform'
+    dest: '{{ output_dir }}/'
+    remote_src: yes
+
+- name: Generate the backend config
+  template:
+    src: backend-config.hcl.j2
+    dest: '{{ output_dir }}/terraform/backend-config.hcl'
+
+- name: Check for terraform init
+  stat:
+    path: '{{ output_dir }}/terraform/.terraform.lock.hcl'
+  register: tf_lock
+
+- block:
+  - name: Initialize Terraform
+    shell: |
+      cd {{ output_dir }}/terraform
+      terraform init -backend-config=backend-config.hcl
+    when: not tf_lock.stat.exists
+    register: tf_init
+  always:
+  - name: Print terraform init output
+    debug:
+      msg: '{{ item }}'
+    loop:
+    - '{{ tf_init.stdout }}'
+    - '{{ tf_init.stderr }}'
+    when: not tf_lock.stat_exists

--- a/collection/roles/provisioner/tasks/setup.yml
+++ b/collection/roles/provisioner/tasks/setup.yml
@@ -29,4 +29,4 @@
     loop:
     - '{{ tf_init.stdout }}'
     - '{{ tf_init.stderr }}'
-    when: not tf_lock.stat_exists
+    when: not tf_lock.stat.exists

--- a/collection/roles/provisioner/templates/tf-destroy.sh.j2
+++ b/collection/roles/provisioner/templates/tf-destroy.sh.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+{{ terraform_binary_path|default("terraform") }} apply -destroy -auto-approve -var 'cluster_name={{ cluster_name }}' -var 'cluster_domain={{ cluster_domain }}' -var 'public_key={{ keypair.public_key }}' -var 'region={{ aws_region }}'

--- a/collection/roles/sneakernet/tasks/connected.yml
+++ b/collection/roles/sneakernet/tasks/connected.yml
@@ -65,34 +65,43 @@
   failed_when: false
   changed_when: false
 
-- name: Mirror content directly into registry
-  include_tasks: mirror-directly-to-registry.yml
-  when: mirror_directly_to_registry|bool == true
-
-- name: Download mirror content on connected host
-  include_tasks: mirror-on-host.yml
-  when: mirror_directly_to_registry|bool == false
-
-- name: Identify results directory
-  find:
-    paths: '{{ mirror_directory }}/oc-mirror-workspace'
-    file_type: directory
-    patterns: "results-*"
-  register: results
-
-- name: Identify results ICSPs and CatalogSources
-  find:
-    paths: '{{ (results.files|last).path }}'
-    file_type: file
-    patterns: '*.yaml'
-  when: results.files|length > 0
-  register: sources
-
-- name: Recover ICSPs and CatalogSources
-  fetch:
-    src: '{{ item.path }}'
-    dest: '{{ mirror_data_recovery_dir }}/'
-    flat: yes
-    mode: '0644'
-  when: results.files|length > 0
-  loop: '{{ sources.files }}'
+- block:
+  - name: Mirror content directly into registry
+    include_tasks: mirror-directly-to-registry.yml
+    when: mirror_directly_to_registry|bool == true
+  
+  - name: Download mirror content on connected host
+    include_tasks: mirror-on-host.yml
+    when: mirror_directly_to_registry|bool == false
+  
+  - name: Identify results directory
+    find:
+      paths: '{{ mirror_directory }}/oc-mirror-workspace'
+      file_type: directory
+      patterns: "results-*"
+    register: results
+  
+  - name: Identify results ICSPs and CatalogSources
+    find:
+      paths: '{{ (results.files|last).path }}'
+      file_type: file
+      patterns: '*.yaml'
+    when: results.files|length > 0
+    register: sources
+  
+  - name: Recover ICSPs and CatalogSources
+    fetch:
+      src: '{{ item.path }}'
+      dest: '{{ mirror_data_recovery_dir }}/'
+      flat: yes
+      mode: '0644'
+    when: results.files|length > 0
+    loop: '{{ sources.files }}'
+  
+  always: # Recover logs even if anything else fails
+  - name: Recover oc-mirror log
+    fetch:
+      src: '{{ mirror_directory }}/.oc-mirror.log'
+      dest: '{{ output_dir }}/'
+      flat: yes
+      mode: '0644'

--- a/collection/roles/sneakernet/tasks/disconnected.yml
+++ b/collection/roles/sneakernet/tasks/disconnected.yml
@@ -41,14 +41,6 @@
   when: mirror_directly_to_registry|bool == false
   loop: '{{ mirrored_content.files }}'
 
-- name: Check for oc and openshift-install
-  stat:
-    path: '{{ ansible_env["HOME"] }}/bin/{{ item }}'
-  register: client_binary
-  loop:
-  - oc
-  - openshift-install
-
 - name: Recover the versions of OpenShift published
   shell: >-
     set -o pipefail &&
@@ -65,6 +57,24 @@
     executable: /bin/bash
   register: mirrored_versions
   changed_when: false
+
+- name: Drop specified oc and openshift-install
+  copy:
+    src: '{{ item }}'
+    dest: '{{ ansible_env["HOME"] }}/bin/{{ item|basename }}'
+    mode: '0755'
+  loop: '{{ oc_bin_list + openshift_install_bin_list }}'
+  vars:
+    oc_bin_list: '{{ [oc_bin] if oc_bin is defined else [] }}'
+    openshift_install_bin_list: '{{ [openshift_install_bin] if openshift_install_bin is defined else [] }}'
+
+- name: Check for oc and openshift-install
+  stat:
+    path: '{{ ansible_env["HOME"] }}/bin/{{ item }}'
+  register: client_binary
+  loop:
+  - oc
+  - openshift-install
 
 - name: Extract the clients from the latest mirror
   shell: |-
@@ -86,6 +96,7 @@
     dest: '{{ bin_recovery_dir }}/'
     flat: yes
     mode: '0755'
+  when: false in client_binary|json_query('results[*].stat.exists')
 
 - name: Identify the latest results
   find:

--- a/collection/roles/sneakernet/tasks/mirror-on-host.yml
+++ b/collection/roles/sneakernet/tasks/mirror-on-host.yml
@@ -1,6 +1,8 @@
 ---
 - name: Mirror content to disk
   command: '{{ oc_mirror_binary_location }} --config {{ ansible_env["HOME"] }}/imageset-config.yml file://{{ mirror_directory }}'
+  args:
+    chdir: '{{ mirror_directory }}'
   when: oc_mirror_config.changed or force_mirror_update|bool
 
 - name: Identify mirrored content


### PR DESCRIPTION
CI needs to have a lot of stuff prebuilt into an image, as we have no way to use a workspace/shared volume mount. This prepares the collection for dealing with that environment, without breaking other deployment methods.