### PR TITLE
Consistent logging

### DIFF
--- a/collection/roles/sneakernet/tasks/connected/mirror.yml
+++ b/collection/roles/sneakernet/tasks/connected/mirror.yml
@@ -33,21 +33,9 @@
     loop: '{{ sources.files }}'
 
   always: # Recover logs even if anything else fails
-  - name: Set the timestamp for the log
-    set_fact:
-      oc_mirror_log_timestamp: '{{ ansible_date_time.iso8601_basic_short  }}'
-
   - name: Recover oc-mirror log
     fetch:
       src: '{{ mirror_directory }}/.oc-mirror.log'
-      dest: '{{ output_dir }}/oc-mirror-{{ oc_mirror_log_timestamp }}.log'
+      dest: '{{ output_dir }}/oc-mirror-{{ ansible_date_time.iso8601_basic_short }}.log'
       flat: yes
       mode: '0644'
-
-  - name: Symlink oc-mirror log to latest
-    file:
-      state: link
-      src: '{{ output_dir }}/oc-mirror-{{ oc_mirror_log_timestamp }}.log'
-      dest: '{{ output_dir }}/.oc-mirror.log'
-      force: yes
-    delegate_to: controller

--- a/collection/roles/sneakernet/tasks/disconnected/publish.yml
+++ b/collection/roles/sneakernet/tasks/disconnected/publish.yml
@@ -36,8 +36,31 @@
   when: mirror_directly_to_registry|bool == false
   register: mirrored_content
 
-- name: Publish mirror data into disconnected registry
-  command: oc-mirror --from "{{ item.path }}" docker://{{ registry_hostname }}/{{ toplevel_namespace }}
-  async: 1800  # wait up to half an hour for publishing
-  when: mirror_directly_to_registry|bool == false
+- block:
+  - name: Publish mirror data into disconnected registry
+    command: oc-mirror --from "{{ item.path }}" docker://{{ registry_hostname }}/{{ toplevel_namespace }}
+    async: 1800  # wait up to half an hour for publishing
+    poll: 5
+    args:
+      chdir: '{{ mirror_directory }}'
+    when: mirror_directly_to_registry|bool == false
+    loop: '{{ mirrored_content.files }}'
+  always: # Recover logs even if publishing fails
+  - name: Recover oc-mirror log
+    fetch:
+      src: '{{ mirror_directory }}/.oc-mirror.log'
+      dest: '{{ output_dir }}/oc-mirror-publish-{{ ansible_date_time.iso8601_basic_short }}.log'
+      flat: yes
+      mode: '0644'
+
+- name: Remove published bundles
+  file:
+    path: '{{ item.path }}'
+    state: absent
   loop: '{{ mirrored_content.files }}'
+
+- name: Remove published bundles from controller
+  file:
+    path: '{{ mirror_data_recovery_dir }}'
+    state: absent
+  delegate_to: controller

--- a/collection/roles/sneakernet/tasks/disconnected/publish.yml
+++ b/collection/roles/sneakernet/tasks/disconnected/publish.yml
@@ -58,7 +58,7 @@
   file:
     path: '{{ item.path }}'
     state: absent
-  loop: '{{ mirrored_content.files }}'
+  loop: '{{ mirrored_content.files|default([]) }}'
 
 - name: Remove published bundles from controller
   file:

--- a/collection/roles/sneakernet/tasks/disconnected/publish.yml
+++ b/collection/roles/sneakernet/tasks/disconnected/publish.yml
@@ -52,6 +52,7 @@
       dest: '{{ output_dir }}/oc-mirror-publish-{{ ansible_date_time.iso8601_basic_short }}.log'
       flat: yes
       mode: '0644'
+    when: mirror_directly_to_registry|bool == false
 
 - name: Remove published bundles
   file:


### PR DESCRIPTION
- Remove flat .oc-mirror.log 
- Collect oc-mirror logs from mirror-to-disk publishes as well
- Ensure mirror-to-disk workflows only try to publish one mirror phase at a time (maybe? needs some extra testing....)