### PR TITLE
Add mirror registry

### DIFF
--- a/collection/galaxy.yml.j2
+++ b/collection/galaxy.yml.j2
@@ -10,7 +10,7 @@ dependencies:
   containers.podman: ">=1.9.0,<2.0.0"
   community.crypto: ">=2.0.2,<3.0.0"
   community.general: ">=4.2.0,<5.0.0"
-  community.okd: ">=2.1.0,<3.0.0"
+  community.okd: ">=2.1.0,<2.2.0"
 license:
 - BSD-2-Clause
 tags:

--- a/collection/roles/installer/defaults/main.yml
+++ b/collection/roles/installer/defaults/main.yml
@@ -22,3 +22,5 @@ install_directory: '{{ ansible_env["HOME"] }}/install'
 
 openshift_modules_packages:
 - python38-pip
+
+release_image_name: release-images

--- a/collection/roles/installer/defaults/main.yml
+++ b/collection/roles/installer/defaults/main.yml
@@ -5,6 +5,10 @@ local_registry_pull_secret: |-
     {{ registry_hostname }}:
       auth: {{ (registry_admin.username + ":" + registry_admin.password)|b64encode }}
       email: {{ registry_admin.email }}
+    "{{ registry_hostname }}:443":
+      auth: {{ (registry_admin.username + ":" + registry_admin.password)|b64encode }}
+      email: {{ registry_admin.email }}
+
 additional_trust_bundle: ""
 
 cluster_subnets: '{{ hostvars.controller.terraform.outputs.vpc.value.private_subnets }}'

--- a/collection/roles/installer/tasks/installed.yml
+++ b/collection/roles/installer/tasks/installed.yml
@@ -50,7 +50,7 @@
     async: 3600  # wait up to an hour for cluster installation
     poll: 5
     environment:
-      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: '{{ registry_hostname }}/{{ toplevel_namespace }}/openshift/release-images:{{ mirrored_versions.stdout_lines|last }}-x86_64'
+      OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: '{{ release_image_override }}'
     args:
       chdir: '{{ install_directory }}'
     register: openshift_install

--- a/collection/roles/installer/tasks/manifests.yml
+++ b/collection/roles/installer/tasks/manifests.yml
@@ -8,6 +8,6 @@
 - name: Create OpenShift manifests
   command: openshift-install create manifests
   environment:
-    OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: '{{ registry_hostname }}/{{ toplevel_namespace }}/openshift/release-images:{{ mirrored_versions.stdout_lines|last }}-x86_64'
+    OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: '{{ release_image_override }}'
   args:
     chdir: '{{ install_directory }}'

--- a/collection/roles/installer/vars/main.yml
+++ b/collection/roles/installer/vars/main.yml
@@ -1,0 +1,2 @@
+---
+release_image_override: '{{ registry_hostname }}/{{ toplevel_namespace }}/openshift/{{ release_image_name }}:{{ mirrored_versions.stdout_lines|last }}-x86_64'

--- a/collection/roles/mirror_registry/README.md
+++ b/collection/roles/mirror_registry/README.md
@@ -1,0 +1,4 @@
+mirror_registry
+===============
+
+Configures a RHEL host with the Mirror Registry for OpenShift, which is based on Red Hat Quay.

--- a/collection/roles/mirror_registry/defaults/main.yml
+++ b/collection/roles/mirror_registry/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+mirror_registry_version: latest
+mirror_registry_download_url: https://mirror.openshift.com/pub/openshift-v4/clients/mirror-registry/{{ mirror_registry_version }}
+controller_mirror_registry_download_dir: '{{ output_dir }}/mirror_registry'

--- a/collection/roles/mirror_registry/tasks/main.yml
+++ b/collection/roles/mirror_registry/tasks/main.yml
@@ -40,7 +40,75 @@
   changed_when: false
   delegate_to: controller
 
+- name: Ensure directories exist
+  become: true
+  file:
+    path: '{{ item }}'
+    state: directory
+  loop:
+  - /etc/quay/pki
+  - /etc/quay/data
+
 - name: Unpack the Mirror Registry installer on the registry node
   unarchive:
     src: '{{ controller_mirror_registry_download_dir }}/mirror-registry.tar.gz'
     dest: '{{ ansible_env["HOME"] }}'
+
+
+- name: Create registry certificates
+  include_role:
+    name: registry_certs
+  vars:
+    cert_directory: /etc/quay/pki
+
+- name: Create Mirror Registry instance
+  shell: >
+    ./mirror-registry install
+    --initUser '{{ registry_admin.username }}'
+    --initPassword '{{ registry_admin.password }}'
+    --quayHostname '{{ private_hostname }}'
+    --quayRoot /etc/quay/data
+    --sslCert /etc/quay/pki/ssl.cert
+    --sslKey /etc/quay/pki/ssl.key
+    --sslCheckSkip
+  args:
+    chdir: '{{ ansible_env["HOME"] }}'
+    creates: /etc/systemd/system/quay-pod.service
+  register: mirror_registry_install
+
+- name: Immediately stop Mirror Registry instance
+  become: yes
+  systemd:
+    name: quay-pod
+    state: stopped
+  when: mirror_registry_install.changed|default(false)
+
+- name: Update Mirror Registry unit with port 443 also
+  become: yes
+  lineinfile:
+    path: /etc/systemd/system/quay-pod.service
+    line: '    --publish 443:8443 \'
+    insertafter: '--publish 8443:8443'
+  register: quay_pod_port
+
+- name: Reload systemd if necessary
+  become: yes
+  systemd:
+    daemon_reload: yes
+  when: quay_pod_port.changed
+
+- name: Ensure Mirror Registry is running
+  become: yes
+  systemd:
+    name: quay-pod
+    state: started
+    enabled: yes
+
+- name: Wait for Mirror Registry to report ready
+  shell: >
+    curl -k https://localhost/api/v1/superuser/registrystatus |
+    python3 -c 'import json, sys; print(json.loads(sys.stdin.read())["status"])'
+  register: quay_status
+  until: '"ready" in quay_status.stdout'
+  retries: 60
+  delay: 5

--- a/collection/roles/mirror_registry/tasks/main.yml
+++ b/collection/roles/mirror_registry/tasks/main.yml
@@ -66,7 +66,7 @@
     ./mirror-registry install
     --initUser '{{ registry_admin.username }}'
     --initPassword '{{ registry_admin.password }}'
-    --quayHostname '{{ private_hostname }}'
+    --quayHostname '{{ private_hostname }}:443'
     --quayRoot /etc/quay/data
     --sslCert /etc/quay/pki/ssl.cert
     --sslKey /etc/quay/pki/ssl.key
@@ -75,27 +75,6 @@
     chdir: '{{ ansible_env["HOME"] }}'
     creates: /etc/systemd/system/quay-pod.service
   register: mirror_registry_install
-
-- name: Immediately stop Mirror Registry instance
-  become: yes
-  systemd:
-    name: quay-pod
-    state: stopped
-  when: mirror_registry_install.changed|default(false)
-
-- name: Update Mirror Registry unit with port 443 also
-  become: yes
-  lineinfile:
-    path: /etc/systemd/system/quay-pod.service
-    line: '    --publish 443:8443 \'
-    insertafter: '--publish 8443:8443'
-  register: quay_pod_port
-
-- name: Reload systemd if necessary
-  become: yes
-  systemd:
-    daemon_reload: yes
-  when: quay_pod_port.changed
 
 - name: Ensure Mirror Registry is running
   become: yes

--- a/collection/roles/mirror_registry/tasks/main.yml
+++ b/collection/roles/mirror_registry/tasks/main.yml
@@ -100,9 +100,14 @@
 - name: Ensure Mirror Registry is running
   become: yes
   systemd:
-    name: quay-pod
+    name: '{{ item }}'
     state: started
     enabled: yes
+  loop:
+  - quay-pod
+  - quay-postgres
+  - quay-redis
+  - quay-app
 
 - name: Wait for Mirror Registry to report ready
   shell: >

--- a/collection/roles/mirror_registry/tasks/main.yml
+++ b/collection/roles/mirror_registry/tasks/main.yml
@@ -53,7 +53,7 @@
   unarchive:
     src: '{{ controller_mirror_registry_download_dir }}/mirror-registry.tar.gz'
     dest: '{{ ansible_env["HOME"] }}'
-
+    creates: '{{ ansible_env["HOME"] }}/mirror-registry'
 
 - name: Create registry certificates
   include_role:

--- a/collection/roles/mirror_registry/tasks/main.yml
+++ b/collection/roles/mirror_registry/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- name: Prepare download directory
+  file:
+    state: directory
+    path: '{{ controller_mirror_registry_download_dir }}'
+  delegate_to: controller
+
+- name: Download the Mirror registry sums
+  get_url:
+    url: '{{ mirror_registry_download_url }}/sha256sum.txt.sig'
+    dest: '{{ controller_mirror_registry_download_dir }}/sha256sum.txt.sig'
+  delegate_to: controller
+
+- name: Decrypt the Mirror registry sums
+  shell: >
+    gpg --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release &&
+    gpg --output ./sha256sum.txt --decrypt sha256sum.txt.sig
+  args:
+    chdir: '{{ controller_mirror_registry_download_dir }}'
+    creates: '{{ controller_mirror_registry_download_dir }}/sha256sum.txt'
+  changed_when: false
+  delegate_to: controller
+
+- name: Download the Mirror Registry installer and signature
+  get_url:
+    url: '{{ mirror_registry_download_url }}/{{ item }}'
+    dest: '{{ controller_mirror_registry_download_dir }}/{{ item }}'
+    checksum: sha256:{{ lookup("file", controller_mirror_registry_download_dir + "/sha256sum.txt")|regex_search("[0-9a-f]+ +" + item|regex_escape)|split(" ")|list|first }}
+  delegate_to: controller
+  loop:
+  - mirror-registry.tar.gz
+  - mirror-registry.tar.gz.asc
+
+- name: Validate the signature on the Mirror Registry installer
+  shell: >
+    gpg --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release &&
+    gpg --verify mirror-registry.tar.gz.asc mirror-registry.tar.gz
+  args:
+    chdir: '{{ controller_mirror_registry_download_dir }}'
+  changed_when: false
+  delegate_to: controller
+
+- name: Unpack the Mirror Registry installer on the registry node
+  unarchive:
+    src: '{{ controller_mirror_registry_download_dir }}/mirror-registry.tar.gz'
+    dest: '{{ ansible_env["HOME"] }}'

--- a/collection/roles/operator_tests/foo/tasks/main.yml
+++ b/collection/roles/operator_tests/foo/tasks/main.yml
@@ -16,6 +16,7 @@
     pull: false
     push: true
     auth_file: '{{ ansible_env["HOME"] }}/.docker/config.json'
+  retries: 2
 
 - name: Merge foo index {{ foo_catalog_version }} into operator catalogs
   catalog_merge:

--- a/collection/roles/operator_tests/foo/tasks/main.yml
+++ b/collection/roles/operator_tests/foo/tasks/main.yml
@@ -16,7 +16,10 @@
     pull: false
     push: true
     auth_file: '{{ ansible_env["HOME"] }}/.docker/config.json'
-  retries: 2
+  register: catalog_publish
+  until: not catalog_publish.failed
+  retries: 5
+  delay: 1
 
 - name: Merge foo index {{ foo_catalog_version }} into operator catalogs
   catalog_merge:

--- a/collection/roles/provisioner/tasks/inventory.yml
+++ b/collection/roles/provisioner/tasks/inventory.yml
@@ -25,7 +25,7 @@
   - name: registry
     groups:
     - connected
-    ansible_host: '{{ terraform.outputs.registry_instance.value.hostname }}'
+    ansible_host: '{{ terraform.outputs.registry_instance.value.ip }}'
     public_hostname: '{{ terraform.outputs.registry_instance.value.hostname }}'
     private_hostname: '{{ terraform.outputs.registry_instance.value.private_hostname }}'
     user: '{{ terraform.outputs.registry_instance.value.username }}'
@@ -34,7 +34,7 @@
   - name: proxy
     groups:
     - connected
-    ansible_host: '{{ terraform.outputs.proxy_instance.value.hostname }}'
+    ansible_host: '{{ terraform.outputs.proxy_instance.value.ip }}'
     public_hostname: '{{ terraform.outputs.proxy_instance.value.hostname }}'
     private_hostname: '{{ terraform.outputs.proxy_instance.value.private_hostname }}'
     user: '{{ terraform.outputs.proxy_instance.value.username }}'

--- a/collection/roles/sneakernet/defaults/main.yml
+++ b/collection/roles/sneakernet/defaults/main.yml
@@ -28,3 +28,6 @@ oc_mirror_additional_images:
 
 # If set to any value other than an empty string, will be used to completely override the templated imageSet
 imageset_config_override: ""
+
+# If set to a non-empty string, oc-mirror will be downloaded (and optionally unarchived) from here if not present
+oc_mirror_download_link: ""

--- a/collection/roles/sneakernet/tasks/connected/binaries.yml
+++ b/collection/roles/sneakernet/tasks/connected/binaries.yml
@@ -56,6 +56,14 @@
     mode: '0755'
   when: oc_mirror_binary.files|length > 0
 
+- name: Recover oc-mirror from the connected node
+  fetch:
+    src: '{{ oc_mirror_binary_location }}'
+    dest: '{{ bin_recovery_dir }}/'
+    flat: yes
+    mode: '0755'
+  when: oc_mirror_binary.files|length == 0
+
 - name: Record the version of oc-mirror on the connected host
   shell: '{{ oc_mirror_binary_location }} version'
   register: oc_mirror_version

--- a/collection/roles/sneakernet/tasks/connected/binaries.yml
+++ b/collection/roles/sneakernet/tasks/connected/binaries.yml
@@ -5,6 +5,16 @@
     state: directory
   delegate_to: controller
 
+- name: Ensure destination bin directory exists
+  file:
+    path: '{{ oc_mirror_binary_location|dirname }}'
+    state: directory
+
+# Where does the oc-mirror binary come from?
+# If binary doesn't exist on controller and no download link specified, compile it using the toolset image
+# If binary doesn't exist on controller and a download link is specified, download and maybe unarchive it
+# If binary does exist on the controller, copy it into place directly from the controller
+
 - name: Check for existing oc-mirror binary
   find:
     paths: '{{ bin_recovery_dir }}'
@@ -15,20 +25,44 @@
 
 - name: Compile oc-mirror from source if needed
   include_tasks: connected/compile.yml
-  when: oc_mirror_binary.files|length == 0
+  when:
+  - oc_mirror_binary.files|length == 0
+  - oc_mirror_download_link == ""
 
-- name: Bring oc-mirror into connected host
+- name: Download oc-mirror
   block:
-  - name: Ensure directories exist
-    file:
-      path: '{{ oc_mirror_binary_location|dirname }}'
-      state: directory
-  - name: Drop oc-mirror in place
-    copy:
-      src: '{{ bin_recovery_dir }}/oc-mirror'
+  - name: Download oc-mirror to binary location
+    get_url:
+      url: '{{ oc_mirror_download_link }}'
       dest: '{{ oc_mirror_binary_location }}'
       mode: '0755'
+    when: not oc_mirror_download_link.endswith(".tar.gz")
+  - name: Download and untar oc-mirrar archive to binary location
+    unarchive:
+      remote_src: yes
+      src: '{{ oc_mirror_download_link }}'
+      dest: '{{ oc_mirror_binary_location|dirname }}/'
+      creates: '{{ oc_mirror_binary_location }}/oc-mirror'
+      mode: '0755'
+    when: oc_mirror_download_link.endswith(".tar.gz")
+  when:
+  - oc_mirror_binary.files|length == 0
+  - oc_mirror_download_link != ""
+
+- name: Copy oc-mirror directly to the connected host
+  copy:
+    src: '{{ bin_recovery_dir }}/oc-mirror'
+    dest: '{{ oc_mirror_binary_location }}'
+    mode: '0755'
   when: oc_mirror_binary.files|length > 0
+
+- name: Record the version of oc-mirror on the connected host
+  shell: '{{ oc_mirror_binary_location }} version'
+  register: oc_mirror_version
+
+- name: Output the oc-mirror version for the logs
+  debug:
+    var: oc_mirror_version
 
 - name: Ensure mirror data directory exists
   file:

--- a/collection/roles/sneakernet/tasks/connected/binaries.yml
+++ b/collection/roles/sneakernet/tasks/connected/binaries.yml
@@ -66,6 +66,7 @@
 
 - name: Record the version of oc-mirror on the connected host
   shell: '{{ oc_mirror_binary_location }} version'
+  changed_when: false
   register: oc_mirror_version
 
 - name: Output the oc-mirror version for the logs

--- a/collection/roles/sneakernet/tasks/connected/compile.yml
+++ b/collection/roles/sneakernet/tasks/connected/compile.yml
@@ -50,10 +50,3 @@
     builder_build.changed or
     repo_download.after != repo_download.before or
     (not oc_mirror.stat.exists)
-
-- name: Recover oc-mirror
-  fetch:
-    src: '{{ oc_mirror_binary_location }}'
-    dest: '{{ bin_recovery_dir }}/'
-    flat: yes
-    mode: '0755'

--- a/collection/roles/sneakernet/tasks/connected/mirror.yml
+++ b/collection/roles/sneakernet/tasks/connected/mirror.yml
@@ -47,7 +47,11 @@
   always: # Recover logs even if anything else fails
   - name: Recover oc-mirror log
     fetch:
-      src: '{{ remote_mirror_data_dir }}/.oc-mirror.log'
+      src: '{{ remote_mirror_data_dir }}/{{ item }}'
       dest: '{{ output_dir }}/oc-mirror-{{ ansible_date_time.iso8601_basic_short }}.log'
       flat: yes
       mode: '0644'
+    ignore_errors: yes
+    loop:
+    - .oc-mirror.log
+    - .openshift_bundle.log

--- a/collection/roles/sneakernet/tasks/connected/mirror.yml
+++ b/collection/roles/sneakernet/tasks/connected/mirror.yml
@@ -1,6 +1,6 @@
 ---
 - block:
-  - name: Mirror content to disk
+  - name: Mirror content to {{ "registry" if mirror_directly_to_registry|bool else "disk" }}
     command: '{{ oc_mirror_binary_location }} --config {{ ansible_env["HOME"] }}/imageset-config.yml {{ mirror_dest }}'
     async: 3600  # wait up to an hour for mirroring
     poll: 5

--- a/collection/roles/sneakernet/tasks/connected/mirror.yml
+++ b/collection/roles/sneakernet/tasks/connected/mirror.yml
@@ -1,18 +1,19 @@
 ---
 - block:
+  - name: Output mirror command
+    debug:
+      var: oc_mirror_command
+
+  - name: Output ImageSetConfiguration
+    debug:
+      var: lookup("template", "imageset-config.yml.j2")
+
   - name: Mirror content to {{ "registry" if mirror_directly_to_registry|bool else "disk" }}
-    command: '{{ oc_mirror_binary_location }} --config {{ ansible_env["HOME"] }}/imageset-config.yml {{ mirror_dest }}'
+    command: '{{ oc_mirror_command }}'
     async: 3600  # wait up to an hour for mirroring
     poll: 5
     args:
       chdir: '{{ remote_mirror_data_dir }}'
-    vars:
-      mirror_dest: >-
-        {% if mirror_directly_to_registry|bool %}
-        docker://{{ registry_hostname }}/{{ toplevel_namespace }}
-        {% else %}
-        file://{{ remote_mirror_data_dir }}
-        {% endif %}
     when: oc_mirror_config.changed or force_mirror_update|bool
 
   - name: Identify results directories

--- a/collection/roles/sneakernet/vars/main.yml
+++ b/collection/roles/sneakernet/vars/main.yml
@@ -3,6 +3,9 @@ local_registry_pull_secret: |-
     {{ registry_hostname }}:
       auth: {{ (registry_admin.username + ":" + registry_admin.password)|b64encode }}
       email: {{ registry_admin.email }}
+    "{{ registry_hostname }}:443":
+      auth: {{ (registry_admin.username + ":" + registry_admin.password)|b64encode }}
+      email: {{ registry_admin.email }}
 
 # Backend config for registry backend
 oc_mirror_metadata_image: '{{ registry_hostname }}/{{ toplevel_namespace }}/imageset-metadata:latest'

--- a/collection/roles/sneakernet/vars/main.yml
+++ b/collection/roles/sneakernet/vars/main.yml
@@ -23,3 +23,12 @@ storage_config_snippets:
     storageConfig:
       local:
         path: '{{ oc_mirror_metadata_path }}'
+
+mirror_dest: >-
+  {% if mirror_directly_to_registry|bool %}
+  docker://{{ registry_hostname }}/{{ toplevel_namespace }}
+  {% else %}
+  file://{{ remote_mirror_data_dir }}
+  {% endif %}
+
+oc_mirror_command: '{{ oc_mirror_binary_location }} --config {{ ansible_env["HOME"] }}/imageset-config.yml {{ mirror_dest }}'

--- a/example/vars/scenario.yml.example
+++ b/example/vars/scenario.yml.example
@@ -28,7 +28,8 @@ mirror_directly_to_registry: true
 # Options:
 #   - docker_registry
 #   - redhat_quay
-registry_type: docker_registry
+#   - mirror_registry
+registry_type: mirror_registry
 
 # operators_to_mirror
 # Determines which operators should be mirrored, installed, and tested


### PR DESCRIPTION
- Pinned OKD at 2.1.x because 2.2.0 doesn't install inside an EE on a non-RHEL host
- Improved output at many stages to be much more descriptive of the actions being taken
  - `oc-mirror version` output
  - Rendered `oc-mirror` command line
  - ImageSetConfiguration dumped out
- Exposed `release_image_override` to make it easier to test changes to the release image publishing location for OSUS
- Moved to connect to terraformed host via IP address instead of hostname to prevent bad DNS cache from causing issues
- Added option to download `oc-mirror` from a URL, either inside a tarball or not, instead of compiling it
- Recover logs from old versions, too
- Added OpenShift Mirror Registry based on Red Hat Quay as a registry option and set it as the default in the scenario example (but not in the actual defaults)