### PR TITLE
Added a check for log retrieval working

### DIFF
--- a/collection/roles/operator_tests/foo/tasks/validate.yml
+++ b/collection/roles/operator_tests/foo/tasks/validate.yml
@@ -10,6 +10,7 @@
     name: foo-operator
   register: operator_log
   until:
+  - operator_log.log is defined
   - foo_expected_versions[foo_catalog_version] in operator_log.log
   retries: 6
   delay: 10


### PR DESCRIPTION
Sometimes the object would register but the log wouldn't be defined yet, so wait until it is